### PR TITLE
Fix unterminated string in competitor scraping API

### DIFF
--- a/backend/app/apis/competitor_scraping/__init__.py
+++ b/backend/app/apis/competitor_scraping/__init__.py
@@ -295,19 +295,9 @@ class CompetitorScraper:
                 
                 # Extract brand if missing
                 if not product.brand:
-                    brand_patterns = [
-                        r'["\']brand["\']\s*:\s*["\']([^"\']*)["\'']',
-                        r'<meta[^>]*property=["\']product:brand["\'][^>]*content=["\']([^"\']*)["\'']',
-                        r'class=["\'][^"\']*(brand|manufacturer)[^"\']*(["\']).+?>([^<]+)',
-                    ]
-                    for pattern in brand_patterns:
-                        try:
-                            match = re.search(pattern, html, re.IGNORECASE)
-                            if match:
-                                product.brand = match.group(-1).strip()  # Get last group
-                                break
-                        except (re.error, IndexError):
-                            continue
+                    match = re.search(r'"brand"\s*:\s*"([^\"]+)"', html, re.IGNORECASE)
+                    if match:
+                        product.brand = match.group(1).strip()
                 
                 return product if product.title and (product.price or len(product.title) > 10) else None
                 


### PR DESCRIPTION
## Summary
- Replace malformed regex block that caused syntax error in `competitor_scraping` API
- Simplify brand extraction with single regex lookup

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689a31e123348320a36c789a04b6b57e